### PR TITLE
Set prev link properly when adding to a 1-item list.

### DIFF
--- a/LRUCache11.hpp
+++ b/LRUCache11.hpp
@@ -204,6 +204,7 @@ struct List {
 			head = n;
 		} else if (head == tail) {
 			head->next = n;
+			n->prev = head;
 		} else {
 			tail->next = n;
 			n->prev = tail;


### PR DESCRIPTION
When there is only 1 item in the list, a newly appended `n` node didn't have the `prev` property set correctly.  This leads to segfaults when calling `get` on the second item, because we later try to de-reference a `nullptr` that should be pointing to `head`.
