### PR TITLE
Implement an emplace method

### DIFF
--- a/LRUCache11.hpp
+++ b/LRUCache11.hpp
@@ -125,6 +125,12 @@ class Cache {
     cache_[k] = keys_.begin();
     prune();
   }
+  void emplace(const Key& k, Value&& v) {
+    Guard g(lock_);
+    keys_.emplace_front(k, std::move(v));
+    cache_[k] = keys_.begin();
+    prune();
+  }
   /**
     for backward compatibity. redirects to tryGetCopy()
    */


### PR DESCRIPTION
In cases where we already know in advance that the value is not in the cache we can avoid the overhead of an additional cache lookup as well as an allocation and copy and just emplace straight into the cache